### PR TITLE
Fix str encoding

### DIFF
--- a/lib/msgpack/inspect/inspector.rb
+++ b/lib/msgpack/inspect/inspector.rb
@@ -290,7 +290,7 @@ module MessagePack
         current[:data] = hex(v)
         if [:fixstr, :str8, :str16, :str32].include?(fmt)
           begin
-            current[:value] = v.encode('UTF-8')
+            current[:value] = v.force_encoding('UTF-8')
           rescue
             current[:error] = $!.message
           end

--- a/test/test_inspector.rb
+++ b/test/test_inspector.rb
@@ -24,5 +24,15 @@ class MessagePackInspectorTest < ::Test::Unit::TestCase
       assert_equal :never_used, ins.data[4][:format]
       assert_equal "msgpack format 'NEVER USED' specified", ins.data[4][:error]
     end
+
+    test 'str' do
+      str = ["Hello", "こんにちは"].map{|s| MessagePack.pack(s) }.join
+      src = StringIO.new(str)
+      ins = MessagePack::Inspect::Inspector.new(src)
+      assert_equal :fixstr, ins.data[0][:format]
+      assert_equal "Hello", ins.data[0][:value]
+      assert_equal :fixstr, ins.data[1][:format]
+      assert_equal "こんにちは", ins.data[1][:value]
+    end
   end
 end


### PR DESCRIPTION
`v.encode('UTF-8')` raises an error such as `:error: '"\xE3" from ASCII-8BIT to UTF-8'` when decoding non-ascii characters.
