### PR TITLE
fix testing long data

### DIFF
--- a/test/test_inspector.rb
+++ b/test/test_inspector.rb
@@ -191,7 +191,7 @@ class MessagePackInspectorTest < ::Test::Unit::TestCase
     )
     test 'str/bin long data' do |data|
       fmt, header, length, leaf, encoding = data
-      io = Tempfile.new
+      io = Tempfile.new("msgpack-inspect-test-")
       io.write header
       (length / leaf.bytesize).times{ io.write leaf }
       io.rewind


### PR DESCRIPTION
The test `str/bin long data` is failed.
It is caused by `Tempfile` and it needs at least one argument `basename`

```
$ bundle exec rake test
/home/taka/.rvm/rubies/ruby-2.2.4/bin/ruby -w -I"lib:test" -Eascii-8bit:ascii-8bit -I"/home/taka/.rvm/gems/ruby-2.2.4/gems/rake-10.5.0/lib" "/home/taka/.rvm/gems/ruby-2.2.4/gems/rake-10.5.0/lib/rake/rake_test_loader.rb" "test/test_foo.rb" "test/test_inspector.rb" 
Loaded suite /home/taka/.rvm/gems/ruby-2.2.4/gems/rake-10.5.0/lib/rake/rake_test_loader
Started
.........................................................................E
======================================================================================================
Error: test: str/bin long data[str16](MessagePackInspectorTest::basic msgpack formats): ArgumentError: wrong number of arguments (0 for 1..2)
/home/taka/.rvm/rubies/ruby-2.2.4/lib/ruby/2.2.0/tempfile.rb:125:in `initialize'
/home/taka/git/oss/pull_req/msgpack-inspect/test/test_inspector.rb:194:in `new'
/home/taka/git/oss/pull_req/msgpack-inspect/test/test_inspector.rb:194:in `block (2 levels) in <class:MessagePackInspectorTest>'
======================================================================================================
E
======================================================================================================
Error: test: str/bin long data[str32](MessagePackInspectorTest::basic msgpack formats): ArgumentError: wrong number of arguments (0 for 1..2)
/home/taka/.rvm/rubies/ruby-2.2.4/lib/ruby/2.2.0/tempfile.rb:125:in `initialize'
/home/taka/git/oss/pull_req/msgpack-inspect/test/test_inspector.rb:194:in `new'
/home/taka/git/oss/pull_req/msgpack-inspect/test/test_inspector.rb:194:in `block (2 levels) in <class:MessagePackInspectorTest>'
======================================================================================================
E
======================================================================================================
Error: test: str/bin long data[bin16](MessagePackInspectorTest::basic msgpack formats): ArgumentError: wrong number of arguments (0 for 1..2)
/home/taka/.rvm/rubies/ruby-2.2.4/lib/ruby/2.2.0/tempfile.rb:125:in `initialize'
/home/taka/git/oss/pull_req/msgpack-inspect/test/test_inspector.rb:194:in `new'
/home/taka/git/oss/pull_req/msgpack-inspect/test/test_inspector.rb:194:in `block (2 levels) in <class:MessagePackInspectorTest>'
======================================================================================================
E
======================================================================================================
Error: test: str/bin long data[bin32](MessagePackInspectorTest::basic msgpack formats): ArgumentError: wrong number of arguments (0 for 1..2)
/home/taka/.rvm/rubies/ruby-2.2.4/lib/ruby/2.2.0/tempfile.rb:125:in `initialize'
/home/taka/git/oss/pull_req/msgpack-inspect/test/test_inspector.rb:194:in `new'
/home/taka/git/oss/pull_req/msgpack-inspect/test/test_inspector.rb:194:in `block (2 levels) in <class:MessagePackInspectorTest>'
======================================================================================================
..............

Finished in 4.287075777 seconds.
------------------------------------------------------------------------------------------------------
91 tests, 323 assertions, 0 failures, 4 errors, 0 pendings, 0 omissions, 0 notifications
95.6044% passed
------------------------------------------------------------------------------------------------------
21.23 tests/s, 75.34 assertions/s
rake aborted!
Command failed with status (1): [ruby -w -I"lib:test" -Eascii-8bit:ascii-8bit -I"/home/taka/.rvm/gems/ruby-2.2.4/gems/rake-10.5.0/lib" "/home/taka/.rvm/gems/ruby-2.2.4/gems/rake-10.5.0/lib/rake/rake_test_loader.rb" "test/test_foo.rb" "test/test_inspector.rb" ]
/home/taka/.rvm/gems/ruby-2.2.4/bin/ruby_executable_hooks:15:in `eval'
/home/taka/.rvm/gems/ruby-2.2.4/bin/ruby_executable_hooks:15:in `<main>'
Tasks: TOP => test
(See full trace by running task with --trace)
```
